### PR TITLE
Code minimisation and robustness improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,20 +5,14 @@ const EventEmitter = require('events')
 exports.devicePixelRatioDetector = class devicePixelRatioDector extends EventEmitter {
   constructor() {
     super()
-    this.callback = (e) => {
-      this.matchMediaMin.removeListener(this.callback)
-      this.matchMediaMax.removeListener(this.callback)
-      const { devicePixelRatio } = window
-      this.matchMediaMin = window.matchMedia(`screen and (min-resolution: ${devicePixelRatio}dppx)`)
-      this.matchMediaMax = window.matchMedia(`screen and (max-resolution: ${devicePixelRatio}dppx)`)
-      this.matchMediaMin.addListener(this.callback)
-      this.matchMediaMax.addListener(this.callback)
-      this.emit('change', devicePixelRatio)
+    let query, callback = () => {
+      query && query.removeListener(callback);
+      const dpr = devicePixelRatio;
+      query = matchMedia(`screen and (min-resolution: ${dpr - 0.001}dppx) and \
+                                     (max-resolution: ${dpr + 0.001}dppx)`)
+      query.addListener(callback)
+      this.emit('change', dpr)
     }
-    const { devicePixelRatio } = window
-    this.matchMediaMin = window.matchMedia(`screen and (min-resolution: ${devicePixelRatio}dppx)`)
-    this.matchMediaMax = window.matchMedia(`screen and (max-resolution: ${devicePixelRatio}dppx)`)
-    this.matchMediaMin.addListener(this.callback)
-    this.matchMediaMax.addListener(this.callback)
+    callback()
   }
 }


### PR DESCRIPTION
Code minimisation changes:

- only one `matchMedia` call is needed (that's what `and` is for);
- deduplicate initialisation code by using the callback for it;
- no need to store things in `this`;
- avoid superfluous mentions of `window`.

Robustness improvement: floating point comparisons need epsilons when
rounding can occur. Previously, zooming in once in Firefox would mostly
break this event listener, because `devicePixelRatio` would be
1.0909091234207153, but media queries use lower precision, and wound up
with using 1.09091dppx which would already be false for one of min and
max due to rounding. This *could* be viewed as a bug in the browser (I
don’t know whether they’d do so), but adding an epsilon to the bounding
range fixes it easily and is the right thing to do.